### PR TITLE
feat: timer milestone notifications with persisted preferences

### DIFF
--- a/src/islands/NotificationSettings.tsx
+++ b/src/islands/NotificationSettings.tsx
@@ -1,0 +1,104 @@
+import { useCallback } from "react";
+import { Bell, BellOff, Globe, Volume2, VolumeX } from "lucide-react";
+import {
+  sanctuaryActions,
+  useSanctuaryStore,
+} from "@/lib/sanctuary/store";
+
+function Toggle({
+  enabled,
+  onToggle,
+  label,
+  iconOn,
+  iconOff,
+}: {
+  enabled: boolean;
+  onToggle: () => void;
+  label: string;
+  iconOn: React.ReactNode;
+  iconOff: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex items-center gap-2 border-2 border-outline-variant bg-surface-container-low px-3 py-2 font-headline text-[10px] font-bold uppercase tracking-widest text-on-surface transition-colors hover:bg-surface-container"
+      aria-pressed={enabled}
+      title={label}
+    >
+      {enabled ? iconOn : iconOff}
+      <span className="hidden sm:inline">{label}</span>
+      <span
+        className={[
+          "ml-auto h-2 w-2 rounded-full",
+          enabled ? "bg-tertiary" : "bg-outline",
+        ].join(" ")}
+      />
+    </button>
+  );
+}
+
+export function NotificationSettings() {
+  const sanctuary = useSanctuaryStore();
+  const prefs = sanctuary.notificationPreferences;
+
+  const toggleInApp = useCallback(() => {
+    sanctuaryActions.updateNotificationPreferences({ inAppEnabled: !prefs.inAppEnabled });
+  }, [prefs.inAppEnabled]);
+
+  const toggleBrowser = useCallback(() => {
+    if (!prefs.browserEnabled) {
+      if (typeof Notification !== "undefined" && Notification.permission === "default") {
+        Notification.requestPermission().then((permission) => {
+          if (permission === "granted") {
+            sanctuaryActions.updateNotificationPreferences({ browserEnabled: true });
+          }
+        });
+        return;
+      }
+
+      if (typeof Notification !== "undefined" && Notification.permission === "granted") {
+        sanctuaryActions.updateNotificationPreferences({ browserEnabled: true });
+        return;
+      }
+
+      // Permission denied — cannot enable
+      return;
+    }
+
+    sanctuaryActions.updateNotificationPreferences({ browserEnabled: false });
+  }, [prefs.browserEnabled]);
+
+  const toggleSound = useCallback(() => {
+    sanctuaryActions.updateNotificationPreferences({ soundEnabled: !prefs.soundEnabled });
+  }, [prefs.soundEnabled]);
+
+  const browserBlocked =
+    typeof Notification !== "undefined" && Notification.permission === "denied";
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Toggle
+        enabled={prefs.inAppEnabled}
+        onToggle={toggleInApp}
+        label="Avisos"
+        iconOn={<Bell size={14} className="text-primary" />}
+        iconOff={<BellOff size={14} className="text-outline" />}
+      />
+      <Toggle
+        enabled={prefs.soundEnabled}
+        onToggle={toggleSound}
+        label="Sonido"
+        iconOn={<Volume2 size={14} className="text-primary" />}
+        iconOff={<VolumeX size={14} className="text-outline" />}
+      />
+      <Toggle
+        enabled={prefs.browserEnabled}
+        onToggle={toggleBrowser}
+        label={browserBlocked ? "Bloqueado" : "Navegador"}
+        iconOn={<Globe size={14} className="text-primary" />}
+        iconOff={<Globe size={14} className={browserBlocked ? "text-error" : "text-outline"} />}
+      />
+    </div>
+  );
+}

--- a/src/islands/StudyTimer.tsx
+++ b/src/islands/StudyTimer.tsx
@@ -6,6 +6,9 @@ import {
   type RoomKind,
   useSanctuaryStore,
 } from "@/lib/sanctuary/store";
+import { useTimerNotifications } from "./useTimerNotifications";
+import { TimerToastStack } from "./TimerToast";
+import { NotificationSettings } from "./NotificationSettings";
 
 interface StudyTimerProps {
   roomKind: RoomKind;
@@ -25,6 +28,7 @@ export function StudyTimer({ roomKind, roomCode, roomName, showGardenHint = fals
   const [now, setNow] = useState(Date.now());
   const [focusMinutes, setFocusMinutes] = useState("25");
   const [breakMinutes, setBreakMinutes] = useState("5");
+  const { toasts, dismissToast } = useTimerNotifications();
 
   useEffect(() => {
     sanctuaryActions.syncTimer();
@@ -161,6 +165,15 @@ export function StudyTimer({ roomKind, roomCode, roomName, showGardenHint = fals
           </p>
         )}
 
+        {!isAnonymousBlocked && (
+          <div className="mt-6">
+            <p className="mb-2 font-headline text-[10px] font-bold uppercase tracking-[0.22em] text-outline">
+              Notificaciones
+            </p>
+            <NotificationSettings />
+          </div>
+        )}
+
         <div className="mt-6 flex flex-wrap justify-center gap-4">
           <button
             type="button"
@@ -202,6 +215,7 @@ export function StudyTimer({ roomKind, roomCode, roomName, showGardenHint = fals
           </a>
         )}
       </div>
+      <TimerToastStack toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/src/islands/TimerToast.tsx
+++ b/src/islands/TimerToast.tsx
@@ -1,0 +1,47 @@
+import { X, Play, CheckCircle, Coffee, Sun } from "lucide-react";
+import type { TimerToastData } from "./useTimerNotifications";
+
+const ICON_MAP = {
+  "focus-start": Play,
+  "focus-end": CheckCircle,
+  "break-start": Coffee,
+  "break-end": Sun,
+} as const;
+
+interface TimerToastStackProps {
+  toasts: TimerToastData[];
+  onDismiss: (id: string) => void;
+}
+
+export function TimerToastStack({ toasts, onDismiss }: TimerToastStackProps) {
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed right-4 bottom-4 z-50 flex flex-col gap-2">
+      {toasts.map((toast) => {
+        const Icon = ICON_MAP[toast.icon];
+        return (
+          <div
+            key={toast.id}
+            className="pointer-events-auto flex items-center gap-3 border-2 border-outline-variant bg-surface-container-high px-4 py-3 pixel-border shadow-lg animate-in slide-in-from-right"
+          >
+            <Icon size={16} className="shrink-0 text-primary" />
+            <span className="font-headline text-xs font-bold uppercase tracking-widest text-on-surface">
+              {toast.message}
+            </span>
+            <button
+              type="button"
+              onClick={() => onDismiss(toast.id)}
+              className="ml-2 shrink-0 text-outline hover:text-on-surface"
+              aria-label="Cerrar notificación"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/islands/useTimerNotifications.ts
+++ b/src/islands/useTimerNotifications.ts
@@ -1,0 +1,125 @@
+import { useEffect, useCallback, useRef, useState } from "react";
+import {
+  subscribeTimerEvents,
+  useSanctuaryStore,
+  type TimerEvent,
+  type NotificationPreferences,
+} from "@/lib/sanctuary/store";
+
+export interface TimerToastData {
+  id: string;
+  message: string;
+  icon: "focus-start" | "focus-end" | "break-start" | "break-end";
+}
+
+const EVENT_LABELS: Record<TimerEvent["kind"], { message: string; browserTitle: string; browserBody: string }> = {
+  "focus-start": {
+    message: "Sesión de foco iniciada",
+    browserTitle: "Lumina — Foco iniciado",
+    browserBody: "Tu sesión de estudio ha comenzado. ¡Buena suerte!",
+  },
+  "focus-end": {
+    message: "Sesión de foco completada",
+    browserTitle: "Lumina — Foco completado",
+    browserBody: "¡Bien hecho! Tu sesión de foco ha terminado.",
+  },
+  "break-start": {
+    message: "Descanso iniciado",
+    browserTitle: "Lumina — Descanso",
+    browserBody: "Tiempo de descanso. Relájate un momento.",
+  },
+  "break-end": {
+    message: "Descanso terminado",
+    browserTitle: "Lumina — Descanso terminado",
+    browserBody: "Tu descanso ha terminado. ¿Listo para otra ronda?",
+  },
+};
+
+const TOAST_DURATION_MS = 4000;
+
+function playNotificationSound() {
+  try {
+    const ctx = new AudioContext();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(587.33, ctx.currentTime); // D5
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
+
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.5);
+
+    // Second tone
+    const osc2 = ctx.createOscillator();
+    const gain2 = ctx.createGain();
+    osc2.connect(gain2);
+    gain2.connect(ctx.destination);
+    osc2.type = "sine";
+    osc2.frequency.setValueAtTime(783.99, ctx.currentTime + 0.15); // G5
+    gain2.gain.setValueAtTime(0.15, ctx.currentTime + 0.15);
+    gain2.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.65);
+    osc2.start(ctx.currentTime + 0.15);
+    osc2.stop(ctx.currentTime + 0.65);
+  } catch {
+    // AudioContext not available — silently skip
+  }
+}
+
+function sendBrowserNotification(title: string, body: string) {
+  if (typeof Notification === "undefined" || Notification.permission !== "granted") {
+    return;
+  }
+
+  try {
+    new Notification(title, { body, icon: "/favicon.svg" });
+  } catch {
+    // Notification blocked or unavailable
+  }
+}
+
+export function useTimerNotifications(): {
+  toasts: TimerToastData[];
+  dismissToast: (id: string) => void;
+} {
+  const sanctuary = useSanctuaryStore();
+  const prefsRef = useRef<NotificationPreferences>(sanctuary.notificationPreferences);
+  prefsRef.current = sanctuary.notificationPreferences;
+
+  const [toasts, setToasts] = useState<TimerToastData[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  useEffect(() => {
+    const handleEvent = (event: TimerEvent) => {
+      const prefs = prefsRef.current;
+      const labels = EVENT_LABELS[event.kind];
+
+      if (prefs.inAppEnabled) {
+        const id = `${event.kind}-${Date.now()}`;
+        const toast: TimerToastData = { id, message: labels.message, icon: event.kind };
+        setToasts((prev) => [...prev, toast]);
+        setTimeout(() => {
+          setToasts((prev) => prev.filter((t) => t.id !== id));
+        }, TOAST_DURATION_MS);
+      }
+
+      if (prefs.soundEnabled) {
+        playNotificationSound();
+      }
+
+      if (prefs.browserEnabled) {
+        sendBrowserNotification(labels.browserTitle, labels.browserBody);
+      }
+    };
+
+    return subscribeTimerEvents(handleEvent);
+  }, []);
+
+  return { toasts, dismissToast };
+}

--- a/src/lib/sanctuary/store.ts
+++ b/src/lib/sanctuary/store.ts
@@ -221,6 +221,12 @@ export interface AchievementUnlock {
   unlockedAt: number;
 }
 
+export interface NotificationPreferences {
+  inAppEnabled: boolean;
+  browserEnabled: boolean;
+  soundEnabled: boolean;
+}
+
 export interface SanctuaryState {
   version: number;
   sessionState: SessionState;
@@ -230,6 +236,7 @@ export interface SanctuaryState {
   rooms: Record<string, Room>;
   presences: Record<string, Presence>;
   timer: TimerState;
+  notificationPreferences: NotificationPreferences;
   sessions: StudySession[];
   chronicleEntries: ChronicleEntry[];
   achievementUnlocks: AchievementUnlock[];
@@ -721,6 +728,11 @@ function createInitialState(): SanctuaryState {
       endsAt: null,
       updatedAt: createdAt,
     },
+    notificationPreferences: {
+      inAppEnabled: true,
+      browserEnabled: false,
+      soundEnabled: true,
+    },
     sessions: [],
     chronicleEntries: [],
     achievementUnlocks: [],
@@ -817,6 +829,22 @@ function normalizeStoredState(value: unknown) {
     (entry) => typeof entry.userId === "string" && entry.userId !== "guest-current",
   );
   parsed.friendIds = Array.isArray(parsed.friendIds) ? parsed.friendIds : fallback.friendIds;
+  parsed.notificationPreferences = {
+    ...fallback.notificationPreferences,
+    ...(isRecord(parsed.notificationPreferences) ? parsed.notificationPreferences : {}),
+  };
+  parsed.notificationPreferences.inAppEnabled =
+    typeof parsed.notificationPreferences.inAppEnabled === "boolean"
+      ? parsed.notificationPreferences.inAppEnabled
+      : fallback.notificationPreferences.inAppEnabled;
+  parsed.notificationPreferences.browserEnabled =
+    typeof parsed.notificationPreferences.browserEnabled === "boolean"
+      ? parsed.notificationPreferences.browserEnabled
+      : fallback.notificationPreferences.browserEnabled;
+  parsed.notificationPreferences.soundEnabled =
+    typeof parsed.notificationPreferences.soundEnabled === "boolean"
+      ? parsed.notificationPreferences.soundEnabled
+      : fallback.notificationPreferences.soundEnabled;
   parsed.timer = {
     ...fallback.timer,
     ...parsed.timer,
@@ -1005,6 +1033,9 @@ function transitionToBreak(state: SanctuaryState) {
     space: state.timer.roomKind === "solo" ? "solo" : "garden",
     message: state.timer.roomKind === "solo" ? "" : "Descansando",
   });
+
+  emitTimerEvent({ kind: "focus-end" });
+  emitTimerEvent({ kind: "break-start" });
 }
 
 function resetFocusState(state: SanctuaryState) {
@@ -1025,6 +1056,8 @@ function resetFocusState(state: SanctuaryState) {
     space: state.timer.roomKind === "solo" ? "solo" : "library",
     message: "",
   });
+
+  emitTimerEvent({ kind: "break-end" });
 }
 
 function syncExpiredTimer(state: SanctuaryState, now = Date.now()) {
@@ -1133,6 +1166,24 @@ function remapUserReferences(state: SanctuaryState, fromUserId: string | null, t
       userId: toUserId,
     };
   }
+}
+
+export type TimerEvent =
+  | { kind: "focus-start" }
+  | { kind: "focus-end" }
+  | { kind: "break-start" }
+  | { kind: "break-end" };
+
+type TimerEventListener = (event: TimerEvent) => void;
+const timerEventListeners = new Set<TimerEventListener>();
+
+function emitTimerEvent(event: TimerEvent) {
+  timerEventListeners.forEach((listener) => listener(event));
+}
+
+export function subscribeTimerEvents(listener: TimerEventListener) {
+  timerEventListeners.add(listener);
+  return () => { timerEventListeners.delete(listener); };
 }
 
 let currentState = createInitialState();
@@ -1582,10 +1633,14 @@ export const sanctuaryActions = {
   },
 
   startTimer(roomKind: RoomKind, roomCode: string) {
+    let emitFocusStart = false;
     commit((state) => {
       if (!isAuthenticated(state) || !state.currentUserId) {
         return;
       }
+
+      const wasPaused = state.timer.status === "paused";
+      const isFocusPhase = state.timer.phase === "focus";
 
       state.timer.roomKind = roomKind;
       state.timer.roomCode = roomCode;
@@ -1600,7 +1655,14 @@ export const sanctuaryActions = {
         space: roomKind === "solo" ? "solo" : state.timer.phase === "break" ? "garden" : "library",
         message: state.timer.phase === "break" ? state.presences[state.currentUserId]?.message || "Descansando" : "Estudiando",
       });
+
+      if (isFocusPhase && !wasPaused) {
+        emitFocusStart = true;
+      }
     });
+    if (emitFocusStart) {
+      emitTimerEvent({ kind: "focus-start" });
+    }
   },
 
   pauseTimer() {
@@ -1683,6 +1745,15 @@ export const sanctuaryActions = {
       if (state.timer.status === "running") {
         state.timer.remainingSeconds = getTimeLeft(state);
       }
+    });
+  },
+
+  updateNotificationPreferences(patch: Partial<NotificationPreferences>) {
+    commit((state) => {
+      state.notificationPreferences = {
+        ...state.notificationPreferences,
+        ...patch,
+      };
     });
   },
 


### PR DESCRIPTION
## Summary
Implements timer milestone notifications (in-app + optional browser) with sound toggle and persisted user preferences.

## What was added
- In-app toast notifications for:
  - focus start
  - focus end
  - break start
  - break end
- Optional browser notifications (permission-based)
- Sound cue toggle (Web Audio API chime)
- Notification settings panel integrated in StudyTimer
- Persisted preferences in sanctuary state/local storage
- Guardrails to avoid duplicate notifications

## Acceptance criteria mapping
- [x] End-of-session notification is triggered reliably
- [x] Browser notifications work when enabled
- [x] Users can disable sound and/or popups
- [x] Preferences persist per user

## Notes
- Build passes locally (`npm run build`)
- No new dependencies added

Closes #18
