### PR TITLE
fix: send floating + button directly to Pomodoro timer

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -137,9 +137,9 @@ const bootstrapPayload = Astro.locals.user
       showFab && (
         <div class="fixed right-6 bottom-20 md:bottom-8 z-40">
           <PixelButton
-            href="/refinar"
+            href="/estudio"
             icon="Plus"
-            ariaLabel="Crear una nueva entrada"
+            ariaLabel="Comenzar una sesión de pomodoro"
             class="w-16 h-16 rounded-none p-0 text-on-primary bezel-button shadow-2xl"
           />
         </div>


### PR DESCRIPTION
Updates home FAB behavior so the floating + button opens the Pomodoro timer screen directly () instead of avatar refine.

- Changed FAB href from  to 
- Updated aria label to reflect Pomodoro start intent