### PR TITLE
fix: repair room join flow and player sync

### DIFF
--- a/src/islands/sanctuary/SharedLibraryRoom.tsx
+++ b/src/islands/sanctuary/SharedLibraryRoom.tsx
@@ -94,7 +94,8 @@ export function SharedLibraryRoom({
     if (currentRoom?.code === cleanCode) return;
 
     void handleJoinPrivateRoom(urlRoomCode);
-  }, [urlRoomCode, isAnonymous, isBusy, currentRoom?.code]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlRoomCode, isAnonymous, currentRoom?.code]);
 
   const handleCreatePrivateRoom = async () => {
     if (isBusy || !roomName.trim()) return;
@@ -114,6 +115,7 @@ export function SharedLibraryRoom({
           data.room.privacy === "public",
         );
         sanctuaryActions.joinPrivateRoom(data.room.code);
+        realtime.joinRoom(data.room.code);
 
         if (inviteIds.length > 0) {
           await Promise.allSettled(
@@ -139,9 +141,12 @@ export function SharedLibraryRoom({
     setIsBusy(true);
     try {
       const cleanCode = codeToJoin.trim().toUpperCase();
+      console.debug("[room-join] Joining room:", cleanCode);
       const res = await fetch(`/api/rooms/${cleanCode}/join`, {
         method: "POST",
       });
+
+      console.debug("[room-join] Join API status:", res.status);
 
       // 200 = joined successfully, 409 = already a member — both are fine
       if (res.ok || res.status === 409) {
@@ -155,10 +160,22 @@ export function SharedLibraryRoom({
             infoData.room.privacy === "public",
           );
           sanctuaryActions.joinPrivateRoom(infoData.room.code);
+          realtime.joinRoom(infoData.room.code);
+          console.debug(
+            "[room-join] Joined room store + realtime:",
+            infoData.room.code,
+          );
+        } else {
+          console.warn(
+            "[room-join] Failed to fetch room info:",
+            infoRes.status,
+          );
         }
+      } else {
+        console.warn("[room-join] Join API rejected:", res.status);
       }
-    } catch {
-      // silent fail
+    } catch (err) {
+      console.warn("[room-join] Join flow error:", err);
     } finally {
       setIsBusy(false);
     }

--- a/src/lib/sanctuary/realtime.ts
+++ b/src/lib/sanctuary/realtime.ts
@@ -137,12 +137,18 @@ function handleMessage(event: MessageEvent) {
 
   switch (msg.type) {
     case "room-state":
+      console.debug(
+        "[realtime] room-state received, members:",
+        msg.members.length,
+      );
       sanctuaryActions.setRemotePresences(msg.members);
       break;
     case "member-joined":
+      console.debug("[realtime] member-joined:", msg.member.userId);
       sanctuaryActions.addRemotePresence(msg.member);
       break;
     case "member-left":
+      console.debug("[realtime] member-left:", msg.userId);
       sanctuaryActions.removeRemotePresence(msg.userId);
       break;
     case "presence-changed":
@@ -237,7 +243,8 @@ export function send(msg: ClientMessage) {
 
 export function joinRoom(roomCode: string) {
   currentRoomCode = roomCode;
-  send({ type: "join-room", roomCode });
+  connect();
+  rawSend({ type: "join-room", roomCode });
 }
 
 export function leaveRoom() {
@@ -261,6 +268,7 @@ export function sendPresenceUpdate(
   };
 
   awayActive = false;
+  connect();
   rawSend({
     type: "presence-update",
     state,

--- a/src/lib/sanctuary/room-join.test.ts
+++ b/src/lib/sanctuary/room-join.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetSanctuaryStoreForTests,
+  getFullState,
+  getCurrentPresence,
+  getRoomMembers,
+  sanctuaryActions,
+} from "./store";
+import type { RoomMemberPresence } from "@/lib/server/ws-types";
+
+function connectUser(id: string, displayName: string, username: string) {
+  sanctuaryActions.connectGitHubAccount({ id, displayName, username });
+}
+
+function makeMemberPresence(
+  overrides: Partial<RoomMemberPresence> & { userId: string },
+): RoomMemberPresence {
+  return {
+    username: overrides.userId,
+    displayName: overrides.userId,
+    avatar: {
+      sex: "masculino",
+      skinTone: "peach",
+      hairStyle: "short-01-buzzcut",
+      hairColor: "brown",
+      accessory: "ninguno",
+      upper: "shirt-01-longsleeve",
+      upperColor: "navy",
+      lower: "pants-03-pants",
+      lowerColor: "black",
+      socks: "socks-01-ankle",
+      socksColor: "white",
+    },
+    state: "idle",
+    phase: "focus",
+    status: "idle",
+    remainingSeconds: 0,
+    message: "",
+    ...overrides,
+  };
+}
+
+describe("room join and player sync", () => {
+  beforeEach(() => {
+    __resetSanctuaryStoreForTests();
+  });
+
+  it("injectRoom + joinPrivateRoom switches to the private room", () => {
+    connectUser("host-1", "Host", "host");
+
+    sanctuaryActions.injectRoom("ABCD1234", "Test Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ABCD1234");
+
+    const state = getFullState();
+    expect(state.currentRoomCode).toBe("ABCD1234");
+    expect(state.rooms["ABCD1234"]).toBeDefined();
+    expect(state.rooms["ABCD1234"].kind).toBe("private");
+
+    const presence = getCurrentPresence(state);
+    expect(presence?.roomCode).toBe("ABCD1234");
+    expect(presence?.roomKind).toBe("private");
+    expect(presence?.space).toBe("library");
+  });
+
+  it("setRemotePresences populates remote member profiles and presences", () => {
+    connectUser("host-1", "Host", "host");
+    sanctuaryActions.injectRoom("ROOM0001", "Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ROOM0001");
+
+    const guest = makeMemberPresence({
+      userId: "guest-1",
+      displayName: "Guest One",
+      username: "guest1",
+      state: "studying",
+      message: "Focusing hard",
+    });
+
+    sanctuaryActions.setRemotePresences([guest]);
+
+    const state = getFullState();
+    expect(state.profiles["guest-1"]).toBeDefined();
+    expect(state.profiles["guest-1"].displayName).toBe("Guest One");
+    expect(state.presences["guest-1"]).toBeDefined();
+    expect(state.presences["guest-1"].state).toBe("studying");
+    expect(state.presences["guest-1"].roomCode).toBe("ROOM0001");
+    expect(state.presences["guest-1"].space).toBe("library");
+
+    const libraryMembers = getRoomMembers(state, "ROOM0001", "library");
+    const guestEntry = libraryMembers.find((m) => m.profile.id === "guest-1");
+    expect(guestEntry).toBeDefined();
+    expect(guestEntry!.profile.displayName).toBe("Guest One");
+  });
+
+  it("addRemotePresence adds a new member and updates existing profiles", () => {
+    connectUser("host-1", "Host", "host");
+    sanctuaryActions.injectRoom("ROOM0002", "Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ROOM0002");
+
+    const guest = makeMemberPresence({
+      userId: "guest-2",
+      displayName: "Guest Two",
+      username: "guest2",
+      state: "idle",
+    });
+
+    sanctuaryActions.addRemotePresence(guest);
+
+    let state = getFullState();
+    expect(state.profiles["guest-2"]).toBeDefined();
+    expect(state.profiles["guest-2"].displayName).toBe("Guest Two");
+    expect(state.presences["guest-2"]).toBeDefined();
+    expect(state.rooms["ROOM0002"].memberIds).toContain("guest-2");
+
+    // Update the same member with new avatar/displayName
+    const updatedGuest = makeMemberPresence({
+      userId: "guest-2",
+      displayName: "Guest Two Updated",
+      username: "guest2",
+      avatar: {
+        sex: "femenino",
+        skinTone: "tan",
+        hairStyle: "short-01-buzzcut",
+        hairColor: "black",
+        accessory: "ninguno",
+        upper: "shirt-01-longsleeve",
+        upperColor: "red",
+        lower: "pants-03-pants",
+        lowerColor: "blue",
+        socks: "socks-01-ankle",
+        socksColor: "white",
+      },
+    });
+
+    sanctuaryActions.addRemotePresence(updatedGuest);
+
+    state = getFullState();
+    expect(state.profiles["guest-2"].displayName).toBe("Guest Two Updated");
+    expect(state.profiles["guest-2"].avatar.upperColor).toBe("red");
+  });
+
+  it("removeRemotePresence cleans up member from presences and room", () => {
+    connectUser("host-1", "Host", "host");
+    sanctuaryActions.injectRoom("ROOM0003", "Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ROOM0003");
+
+    sanctuaryActions.addRemotePresence(
+      makeMemberPresence({ userId: "guest-3" }),
+    );
+
+    let state = getFullState();
+    expect(state.presences["guest-3"]).toBeDefined();
+
+    sanctuaryActions.removeRemotePresence("guest-3");
+
+    state = getFullState();
+    expect(state.presences["guest-3"]).toBeUndefined();
+    expect(state.rooms["ROOM0003"].memberIds).not.toContain("guest-3");
+  });
+
+  it("updateRemotePresence changes state and space correctly", () => {
+    connectUser("host-1", "Host", "host");
+    sanctuaryActions.injectRoom("ROOM0004", "Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ROOM0004");
+
+    sanctuaryActions.addRemotePresence(
+      makeMemberPresence({ userId: "guest-4", state: "idle" }),
+    );
+
+    sanctuaryActions.updateRemotePresence({
+      userId: "guest-4",
+      state: "studying",
+      phase: "focus",
+      status: "running",
+      remainingSeconds: 1500,
+      message: "Deep focus",
+    });
+
+    let state = getFullState();
+    expect(state.presences["guest-4"].state).toBe("studying");
+    expect(state.presences["guest-4"].space).toBe("library");
+
+    sanctuaryActions.updateRemotePresence({
+      userId: "guest-4",
+      state: "break",
+      phase: "break",
+      status: "running",
+      remainingSeconds: 300,
+      message: "Taking a break",
+    });
+
+    state = getFullState();
+    expect(state.presences["guest-4"].state).toBe("break");
+    expect(state.presences["guest-4"].space).toBe("garden");
+  });
+
+  it("selectPublicRoom switches back from private to public", () => {
+    connectUser("host-1", "Host", "host");
+    sanctuaryActions.injectRoom("ROOM0005", "Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ROOM0005");
+
+    expect(getFullState().currentRoomCode).toBe("ROOM0005");
+
+    sanctuaryActions.selectPublicRoom();
+
+    const state = getFullState();
+    expect(state.currentRoomCode).toBe("gran-lectorio");
+  });
+
+  it("getRoomMembers filters by space correctly", () => {
+    connectUser("host-1", "Host", "host");
+    sanctuaryActions.injectRoom("ROOM0006", "Room", "host-1", false);
+    sanctuaryActions.joinPrivateRoom("ROOM0006");
+
+    sanctuaryActions.addRemotePresence(
+      makeMemberPresence({ userId: "lib-user", state: "studying" }),
+    );
+    sanctuaryActions.addRemotePresence(
+      makeMemberPresence({ userId: "garden-user", state: "break" }),
+    );
+
+    const state = getFullState();
+    const library = getRoomMembers(state, "ROOM0006", "library");
+    const garden = getRoomMembers(state, "ROOM0006", "garden");
+
+    expect(library.some((m) => m.profile.id === "lib-user")).toBe(true);
+    expect(library.some((m) => m.profile.id === "garden-user")).toBe(false);
+    expect(garden.some((m) => m.profile.id === "garden-user")).toBe(true);
+    expect(garden.some((m) => m.profile.id === "lib-user")).toBe(false);
+  });
+});

--- a/src/lib/sanctuary/store.ts
+++ b/src/lib/sanctuary/store.ts
@@ -3154,6 +3154,9 @@ export const sanctuaryActions = {
           bio: "",
           createdAt: Date.now(),
         };
+      } else {
+        state.profiles[member.userId].avatar = member.avatar;
+        state.profiles[member.userId].displayName = member.displayName;
       }
 
       state.presences[member.userId] = {

--- a/src/lib/server/ws.ts
+++ b/src/lib/server/ws.ts
@@ -238,6 +238,9 @@ function handleJoinRoom(userId: string, roomCode: string, ws: WebSocket): void {
   // Verify the user is a member of this room in the database
   const isMember = checkRoomMembership.get(roomCode, userId);
   if (!isMember) {
+    console.debug(
+      `[ws] join-room denied: user ${userId} is not a member of room ${roomCode}`,
+    );
     send(ws, { type: "error", message: "You are not a member of this room." });
     return;
   }
@@ -284,6 +287,9 @@ function handleJoinRoom(userId: string, roomCode: string, ws: WebSocket): void {
     const mp = buildMemberPresence(uid);
     if (mp) members.push(mp);
   }
+  console.debug(
+    `[ws] user ${userId} joined room ${roomCode}, occupants: ${occupants.size}`,
+  );
   send(ws, { type: "room-state", members });
 }
 


### PR DESCRIPTION
## Summary

Fixes multiplayer room join bug where guest entering a room code from the shared library page fails to connect, and avatars don't appear.

## Root cause

Multiple interacting issues in the join flow:

1. **`realtime.joinRoom()` didn't ensure WebSocket was connected** — if the WS hadn't finished connecting when the join message was sent, the message was silently dropped. While a recovery mechanism existed in the `open` handler, it was fragile and produced user-visible failures.

2. **`handleJoinPrivateRoom` relied solely on a React useEffect to trigger `realtime.joinRoom()`** — if `currentRoomCode` didn't change (e.g. re-joining the same room), the WS join was never triggered. The join also depended on React's render cycle, adding unnecessary delay.

3. **`addRemotePresence` didn't update existing profiles** — when a guest joined and their profile was already cached on the host side (e.g. from friends list), the avatar and displayName from the WS `member-joined` message were ignored. This caused stale/missing avatars.

4. **`isBusy` in the auto-join useEffect dependency array** — caused the effect to re-fire on every `isBusy` state transition, potentially creating unnecessary retry loops on failed joins.

## Files/blocks changed

| File | Change |
|------|--------|
| `src/lib/sanctuary/realtime.ts` | `joinRoom()` and `sendPresenceUpdate()` now call `connect()` before sending; added debug logs for `room-state`, `member-joined`, `member-left` |
| `src/islands/sanctuary/SharedLibraryRoom.tsx` | `handleJoinPrivateRoom` and `handleCreatePrivateRoom` now call `realtime.joinRoom()` directly after store update; removed `isBusy` from auto-join useEffect deps; added debug logging with `[room-join]` prefix |
| `src/lib/sanctuary/store.ts` | `addRemotePresence` now updates `avatar` and `displayName` on existing profiles (matching `setRemotePresences` behavior) |
| `src/lib/server/ws.ts` | Added `[ws]` debug logs for join-room denied and join-room success with occupant count |
| `src/lib/sanctuary/room-join.test.ts` | **New** — 7 tests covering `injectRoom`+`joinPrivateRoom`, `setRemotePresences`, `addRemotePresence` (including profile update), `removeRemotePresence`, `updateRemotePresence`, `selectPublicRoom`, and `getRoomMembers` space filtering |

## How to verify manually

**Setup:** Two browser sessions (or incognito), both logged in with different accounts.

1. **Host** goes to `/biblioteca-compartida` → clicks "Crear sala" → copies room code
2. **Guest** goes to `/biblioteca-compartida` → pastes code in "Código de invitación" → clicks "Entrar"
3. **Verify:** Guest sees host's avatar in the canvas. Host sees guest's avatar appear. Both show in "Miembros visibles" sidebar.
4. **Verify logs:** Open browser console — look for `[room-join]` and `[realtime]` debug messages confirming the flow.
5. **Test presence sync:** Host starts a timer → guest should see host's state change to "Estudiando".
6. **Test URL join:** Guest navigates directly to `/biblioteca-compartida?codigo=<CODE>` → should auto-join and see host.

## Added debug logs

- `[room-join] Joining room: <code>` — client, before API call
- `[room-join] Join API status: <status>` — client, after API response
- `[room-join] Joined room store + realtime: <code>` — client, after successful join
- `[room-join] Join API rejected: <status>` / `Failed to fetch room info` / `Join flow error` — client, on failures
- `[realtime] room-state received, members: <count>` — client, on WS room-state
- `[realtime] member-joined: <userId>` — client, on WS member-joined
- `[realtime] member-left: <userId>` — client, on WS member-left
- `[ws] join-room denied: user <id> is not a member of room <code>` — server
- `[ws] user <id> joined room <code>, occupants: <count>` — server

🤖 Generated with [Claude Code](https://claude.com/claude-code)